### PR TITLE
Exclude .git from docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
-keys/
-sish
+/.git/
+/keys/
+/sish


### PR DESCRIPTION
You do not want `.git` dir included in docker image. It may accidentally reveal something secret, git stash or other branches from example.