### PR TITLE
Improve logging and block direct requests to server IP

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,8 +140,10 @@ Usage of ./sish:
         Directory for public keys for pubkey auth (default "pubkeys/")
   -sish.logtoclient
         Whether or not to log http requests to the client
-  -sish.logdetail
-        The request log detail level 0 is most compact, 3 is most verbose (default 3)
+  -sish.logtimestampformat
+        Log timestamp format (default "2006-01-02 15:04:05")
+  -sish.logformat
+        Custom log format. A string made up of required parts ({timestamp}, {host}, {status}, {latency}, {clientip}, {method}, {methodp}, {path}, {error}) and delimiters (one or more of space, pipe or comma). "methodp" differed from "method" in that is is padded to 4 characters (default "{timestamp} | {host} | {status} | {latency} | {clientip} | {methodp} | {path} \n{error}")
   -sish.password string
         Password to use for password auth (default "S3Cr3tP4$$W0rD")
   -sish.pkloc string

--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ Usage of ./sish:
         Ports that are allowed to be bound (default "0,1024-65535")
   -sish.cleanupunbound
         Whether or not to cleanup unbound (forwarded) SSH connections (default true)
+  -sish.clientlogformat string
+        The client log format string, created from available fields ({timestamp}, {host}, {status}, {latency}, {latencyp}, {clientip}, {clientipp, {method}, {methodp} and {path}) and delimiters. {latencyp}, {clientipp} and {methodp} are padded to deliver fixed column widths. {newline} will inject a newline (default "{timestamp} | {host} | {status} | {latencyp} | {clientipp} | {methodp} | {path}")
   -sish.debug
         Whether or not to print debug information
   -sish.domain string
@@ -158,8 +160,6 @@ Usage of ./sish:
         Where to redirect the root domain to (default "https://github.com/antoniomika/sish")
   -sish.serverlogformat string
         The server log format string, created from available fields ({timestamp}, {host}, {status}, {latency}, {latencyp}, {clientip}, {clientipp}, {method}, {methodp}, {path} and {error}) and delimiters. {latencyp}, {clientipp} and {methodp} are padded to deliver fixed column widths. {newline} will inject a newline (default "{timestamp} | {host} | {status} | {latencyp} | {clientipp} | {methodp} | {path}")
-  -sish.clientlogformat string
-        The client log format string, created from available fields ({timestamp}, {host}, {status}, {latency}, {latencyp}, {clientip}, {clientipp, {method}, {methodp} and {path}) and delimiters. {latencyp}, {clientipp} and {methodp} are padded to deliver fixed column widths. {newline} will inject a newline (default "{timestamp} | {host} | {status} | {latencyp} | {clientipp} | {methodp} | {path}")
   -sish.subdomainlen int
         The length of the random subdomain to generate (default 3)
   -sish.tcpalias

--- a/README.md
+++ b/README.md
@@ -138,12 +138,10 @@ Usage of ./sish:
         Number of seconds to wait for activity before closing a connection (default 5)
   -sish.keysdir string
         Directory for public keys for pubkey auth (default "pubkeys/")
+  -sish.logtimestampformat string
+        Log timestamp format (default "2006-01-02 15:04:05")
   -sish.logtoclient
         Whether or not to log http requests to the client
-  -sish.logtimestampformat
-        Log timestamp format (default "2006-01-02 15:04:05")
-  -sish.logformat
-        Custom log format. A string made up of required parts ({timestamp}, {host}, {status}, {latency}, {clientip}, {method}, {methodp}, {path}, {error}) and delimiters (one or more of space, pipe or comma). "methodp" differed from "method" in that is is padded to 4 characters (default "{timestamp} | {host} | {status} | {latency} | {clientip} | {methodp} | {path} \n{error}")
   -sish.password string
         Password to use for password auth (default "S3Cr3tP4$$W0rD")
   -sish.pkloc string
@@ -158,6 +156,10 @@ Usage of ./sish:
         Whether or not to redirect the root domain (default true)
   -sish.redirectrootlocation string
         Where to redirect the root domain to (default "https://github.com/antoniomika/sish")
+  -sish.serverlogformat string
+        The server log format string, created from available fields ({timestamp}, {host}, {status}, {latency}, {latencyp}, {clientip}, {clientipp}, {method}, {methodp}, {path} and {error}) and delimiters. {latencyp}, {clientipp} and {methodp} are padded to deliver fixed column widths. {newline} will inject a newline (default "{timestamp} | {host} | {status} | {latencyp} | {clientipp} | {methodp} | {path}")
+  -sish.clientlogformat string
+        The client log format string, created from available fields ({timestamp}, {host}, {status}, {latency}, {latencyp}, {clientip}, {clientipp, {method}, {methodp} and {path}) and delimiters. {latencyp}, {clientipp} and {methodp} are padded to deliver fixed column widths. {newline} will inject a newline (default "{timestamp} | {host} | {status} | {latencyp} | {clientipp} | {methodp} | {path}")
   -sish.subdomainlen int
         The length of the random subdomain to generate (default 3)
   -sish.tcpalias

--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ Usage of ./sish:
         Directory for public keys for pubkey auth (default "pubkeys/")
   -sish.logtoclient
         Whether or not to log http requests to the client
+  -sish.logdetail
+        The request log detail level 0 is most compact, 3 is most verbose (default 3)
   -sish.password string
         Password to use for password auth (default "S3Cr3tP4$$W0rD")
   -sish.pkloc string

--- a/channels.go
+++ b/channels.go
@@ -24,7 +24,7 @@ func handleSession(newChannel ssh.NewChannel, sshConn *SSHConnection, state *Sta
 		log.Println("Handling session for connection:", connection)
 	}
 
-	writeToSession(connection, aurora.BgRed("Press Ctrl-C to close the session.").String()+"\r\n")
+	writeToSession(connection, aurora.Red("Press Ctrl-C to close the session.").String()+"\r\n")
 
 	go func() {
 		for {

--- a/http.go
+++ b/http.go
@@ -77,44 +77,29 @@ func startHTTPHandler(state *State) {
 		}
 
 		logLine := ""
-		switch *logDetail {
-		case 0:
-			logLine = fmt.Sprintf("%v %s %-4s %s\n%s",
-				param.TimeStamp.Format("2006-01-02 15:04:05"),
-				statusFormatted,
-				methodFormatted,
-				param.Path,
-				param.ErrorMessage,
-			)
-		case 1:
-			logLine = fmt.Sprintf("%v | %s | % 8s | %-4s %s\n%s",
-				param.TimeStamp.Format("2006-01-02 15:04:05"),
-				statusFormatted,
-				RoundN(param.Latency, 4),
-				methodFormatted,
-				param.Path,
-				param.ErrorMessage,
-			)
-		case 2:
-			logLine = fmt.Sprintf("%v | %s | % 8s | %-4s %s\n%s",
-				param.TimeStamp.Format("2006-01-02 15:04:05"),
-				statusFormatted,
-				RoundN(param.Latency, 4),
-				methodFormatted,
-				param.Path,
-				param.ErrorMessage,
-			)
-		default:
-			logLine = fmt.Sprintf("%v | %s | %s | % 8s | %15s | %-4s %s\n%s",
-				param.TimeStamp.Format("2006-01-02 15:04:05"),
-				param.Request.Host,
-				statusFormatted,
-				RoundN(param.Latency, 4),
-				param.ClientIP,
-				methodFormatted,
-				param.Path,
-				param.ErrorMessage,
-			)
+		for _, logPart := range logFormatParts {
+			switch logPart {
+			case "{timestamp}":
+				logLine += fmt.Sprintf("%v", param.TimeStamp.Format(*logTimestampFormat))
+			case "{host}":
+				logLine += fmt.Sprintf("%s", param.Request.Host)
+			case "{status}":
+				logLine += fmt.Sprintf("%s", statusFormatted)
+			case "{latency}":
+				logLine += fmt.Sprintf("% 8s", RoundN(param.Latency, 4))
+			case "{clientip}":
+				logLine += fmt.Sprintf("%15s", param.ClientIP)
+			case "{method}":
+				logLine += fmt.Sprintf("%s", methodFormatted)
+			case "{methodp}":
+				logLine += fmt.Sprintf("%-4s", methodFormatted)
+			case "{path}":
+				logLine += fmt.Sprintf("%s", param.Path)
+			case "{error}":
+				logLine += fmt.Sprintf("%s", param.ErrorMessage)
+			default:
+				logLine += fmt.Sprintf("%s", logPart)
+			}
 		}
 
 		if *logToClient {

--- a/http.go
+++ b/http.go
@@ -76,16 +76,47 @@ func startHTTPHandler(state *State) {
 			// Truncate in a golang < 1.8 safe way
 			param.Latency = param.Latency - param.Latency%time.Second
 		}
-		logLine := fmt.Sprintf("%v | %s | %s | % 8s | %15s | %-4s %s\n%s",
-			param.TimeStamp.Format("2006-01-02 15:04:05"),
-			param.Request.Host,
-			statusFormatted,
-			RoundN(param.Latency, 4),
-			param.ClientIP,
-			methodFormatted,
-			param.Path,
-			param.ErrorMessage,
-		)
+
+		logLine := ""
+		switch *logDetail {
+		case 0:
+			logLine = fmt.Sprintf("%v %s %-4s %s\n%s",
+				param.TimeStamp.Format("2006-01-02 15:04:05"),
+				statusFormatted,
+				methodFormatted,
+				param.Path,
+				param.ErrorMessage,
+			)
+		case 1:
+			logLine = fmt.Sprintf("%v | %s | % 8s | %-4s %s\n%s",
+				param.TimeStamp.Format("2006-01-02 15:04:05"),
+				statusFormatted,
+				RoundN(param.Latency, 4),
+				methodFormatted,
+				param.Path,
+				param.ErrorMessage,
+			)
+		case 2:
+			logLine = fmt.Sprintf("%v | %s | % 8s | %-4s %s\n%s",
+				param.TimeStamp.Format("2006-01-02 15:04:05"),
+				statusFormatted,
+				RoundN(param.Latency, 4),
+				methodFormatted,
+				param.Path,
+				param.ErrorMessage,
+			)
+		default:
+			logLine = fmt.Sprintf("%v | %s | %s | % 8s | %15s | %-4s %s\n%s",
+				param.TimeStamp.Format("2006-01-02 15:04:05"),
+				param.Request.Host,
+				statusFormatted,
+				RoundN(param.Latency, 4),
+				param.ClientIP,
+				methodFormatted,
+				param.Path,
+				param.ErrorMessage,
+			)
+		}
 
 		if *logToClient {
 			hostname := strings.Split(param.Request.Host, ":")[0]

--- a/http.go
+++ b/http.go
@@ -156,26 +156,7 @@ func startHTTPHandler(state *State) {
 	log.Fatal(r.Run(*httpAddr))
 }
 
-// Round a duration, see original source here: https://play.golang.org/p/WjfKwhhjL5
-func Round(d, r time.Duration) time.Duration {
-	if r <= 0 {
-		return d
-	}
-	neg := d < 0
-	if neg {
-		d = -d
-	}
-	if m := d % r; m+m < r {
-		d = d - m
-	} else {
-		d = d + r - m
-	}
-	if neg {
-		return -d
-	}
-	return d
-}
-
+// Round duration to N decimal points. Original source here: https://play.golang.org/p/WjfKwhhjL5
 func RoundN(d time.Duration, n int) time.Duration {
 	if n < 1 {
 		return d
@@ -183,24 +164,24 @@ func RoundN(d time.Duration, n int) time.Duration {
 	if d >= time.Hour {
 		k := digits(d / time.Hour)
 		if k >= n {
-			return Round(d, time.Hour*time.Duration(math.Pow10(k-n)))
+			return d.Round(time.Hour*time.Duration(math.Pow10(k-n)))
 		}
 		n -= k
 		k = digits(d % time.Hour / time.Minute)
 		if k >= n {
-			return Round(d, time.Minute*time.Duration(math.Pow10(k-n)))
+			return d.Round(time.Minute*time.Duration(math.Pow10(k-n)))
 		}
-		return Round(d, time.Duration(float64(100*time.Second)*math.Pow10(k-n)))
+		return d.Round(time.Duration(float64(100*time.Second)*math.Pow10(k-n)))
 	}
 	if d >= time.Minute {
 		k := digits(d / time.Minute)
 		if k >= n {
-			return Round(d, time.Minute*time.Duration(math.Pow10(k-n)))
+			return d.Round(time.Minute*time.Duration(math.Pow10(k-n)))
 		}
-		return Round(d, time.Duration(float64(100*time.Second)*math.Pow10(k-n)))
+		return d.Round(time.Duration(float64(100*time.Second)*math.Pow10(k-n)))
 	}
 	if k := digits(d); k > n {
-		return Round(d, time.Duration(math.Pow10(k-n)))
+		return d.Round(time.Duration(math.Pow10(k-n)))
 	}
 	return d
 }

--- a/http.go
+++ b/http.go
@@ -164,24 +164,24 @@ func RoundN(d time.Duration, n int) time.Duration {
 	if d >= time.Hour {
 		k := digits(d / time.Hour)
 		if k >= n {
-			return d.Round(time.Hour*time.Duration(math.Pow10(k-n)))
+			return d.Round(time.Hour * time.Duration(math.Pow10(k-n)))
 		}
 		n -= k
 		k = digits(d % time.Hour / time.Minute)
 		if k >= n {
-			return d.Round(time.Minute*time.Duration(math.Pow10(k-n)))
+			return d.Round(time.Minute * time.Duration(math.Pow10(k-n)))
 		}
-		return d.Round(time.Duration(float64(100*time.Second)*math.Pow10(k-n)))
+		return d.Round(time.Duration(float64(100*time.Second) * math.Pow10(k-n)))
 	}
 	if d >= time.Minute {
 		k := digits(d / time.Minute)
 		if k >= n {
-			return d.Round(time.Minute*time.Duration(math.Pow10(k-n)))
+			return d.Round(time.Minute * time.Duration(math.Pow10(k-n)))
 		}
-		return d.Round(time.Duration(float64(100*time.Second)*math.Pow10(k-n)))
+		return d.Round(time.Duration(float64(100*time.Second) * math.Pow10(k-n)))
 	}
 	if k := digits(d); k > n {
-		return d.Round(time.Duration(math.Pow10(k-n)))
+		return d.Round(time.Duration(math.Pow10(k - n)))
 	}
 	return d
 }

--- a/http.go
+++ b/http.go
@@ -4,19 +4,18 @@ import (
 	"crypto/tls"
 	"fmt"
 	"log"
+	"math"
 	"net"
 	"net/http"
 	"net/http/httputil"
 	"path/filepath"
 	"strings"
 	"time"
-	"math"
-
-	"github.com/logrusorgru/aurora"
-	"github.com/gorilla/websocket"
-	"github.com/koding/websocketproxy"
 
 	"github.com/gin-gonic/gin"
+	"github.com/gorilla/websocket"
+	"github.com/koding/websocketproxy"
+	"github.com/logrusorgru/aurora"
 )
 
 // ProxyHolder holds proxy and connection info
@@ -62,13 +61,13 @@ func startHTTPHandler(state *State) {
 		if param.IsOutputColor() {
 			switch {
 			case param.StatusCode >= http.StatusOK && param.StatusCode < http.StatusMultipleChoices:
-					statusFormatted = aurora.Sprintf(aurora.Green("%3d"), param.StatusCode)
+				statusFormatted = aurora.Sprintf(aurora.Green("%3d"), param.StatusCode)
 			case param.StatusCode >= http.StatusMultipleChoices && param.StatusCode < http.StatusBadRequest:
-					statusFormatted = aurora.Sprintf(aurora.Yellow("%3d"), param.StatusCode)
+				statusFormatted = aurora.Sprintf(aurora.Yellow("%3d"), param.StatusCode)
 			case param.StatusCode >= http.StatusBadRequest && param.StatusCode < http.StatusInternalServerError:
-					statusFormatted = aurora.Sprintf(aurora.Red("%3d"), param.StatusCode)
+				statusFormatted = aurora.Sprintf(aurora.Red("%3d"), param.StatusCode)
 			default:
-					statusFormatted = aurora.Sprintf(aurora.Red("%3d"), param.StatusCode)
+				statusFormatted = aurora.Sprintf(aurora.Red("%3d"), param.StatusCode)
 			}
 		}
 

--- a/main.go
+++ b/main.go
@@ -79,8 +79,10 @@ var (
 	tcpAlias             = flag.Bool("sish.tcpalias", false, "Whether or not to allow the use of TCP aliasing")
 	logToClient          = flag.Bool("sish.logtoclient", false, "Whether or not to log http requests to the client")
 	logTimestampFormat   = flag.String("sish.logtimestampformat", "2006-01-02 15:04:05", "Log timestamp format")
-	logFormat            = flag.String("sish.logformat", "{timestamp} | {host} | {status} | {latency} | {clientip} | {methodp} | {path} \n{error}", "Custom log format")
-	logFormatParts       = []string{""}
+	serverLogFormat      = flag.String("sish.serverlogformat", "{timestamp} | {host} | {status} | {latencyp} | {clientipp} | {methodp} | {path}", "The server log format")
+	serverLogFormatParts = []string{""}
+	clientLogFormat      = flag.String("sish.clientlogformat", "{timestamp} | {host} | {status} | {latencyp} | {clientipp} | {methodp} | {path}", "The client log format")
+	clientLogFormatParts = []string{""}
 	idleTimeout          = flag.Int("sish.idletimeout", 5, "Number of seconds to wait for activity before closing a connection")
 	bannedSubdomainList  = []string{""}
 	filter               *ipfilter.IPFilter
@@ -157,11 +159,16 @@ func main() {
 		filter = ipfilter.NewNoDB(ipfilterOpts)
 	}
 
-	// Get log format parts and delimiters (1..n space, pipe, comma or newline)
-	re := regexp.MustCompile("({[a-z]+}|[ \\|,\\n]+)")
-	tmpLogFormatParts := re.FindAllStringSubmatch(*logFormat, -1)
+	// Get log format parts and delimiters
+	re := regexp.MustCompile(`({[a-z]+}|[ \w\d:\|,;=]*)`)
+	tmpLogFormatParts := re.FindAllStringSubmatch(*serverLogFormat, -1)
 	for _, logPart := range tmpLogFormatParts {
-		logFormatParts = append(logFormatParts , logPart[1])
+		serverLogFormatParts = append(serverLogFormatParts, logPart[1])
+	}
+
+	tmpLogFormatParts = re.FindAllStringSubmatch(*clientLogFormat, -1)
+	for _, logPart := range tmpLogFormatParts {
+		clientLogFormatParts = append(clientLogFormatParts, logPart[1])
 	}
 
 	watchCerts()

--- a/main.go
+++ b/main.go
@@ -79,9 +79,9 @@ var (
 	tcpAlias             = flag.Bool("sish.tcpalias", false, "Whether or not to allow the use of TCP aliasing")
 	logToClient          = flag.Bool("sish.logtoclient", false, "Whether or not to log http requests to the client")
 	logTimestampFormat   = flag.String("sish.logtimestampformat", "2006-01-02 15:04:05", "Log timestamp format")
-	serverLogFormat      = flag.String("sish.serverlogformat", "{timestamp} | {host} | {status} | {latencyp} | {clientipp} | {methodp} | {path}", "The server log format")
+	serverLogFormat      = flag.String("sish.serverlogformat", "{timestamp} | {host} | {status} | {latencyp} | {clientipp} | {methodp} | {path}", "The server log format string, created from available fields ({timestamp}, {host}, {status}, {latency}, {latencyp}, {clientip}, {clientipp}, {method}, {methodp}, {path} and {error}) and delimiters. {latencyp}, {clientipp} and {methodp} are padded to deliver fixed column widths. {newline} will inject a newline")
 	serverLogFormatParts = []string{""}
-	clientLogFormat      = flag.String("sish.clientlogformat", "{timestamp} | {host} | {status} | {latencyp} | {clientipp} | {methodp} | {path}", "The client log format")
+	clientLogFormat      = flag.String("sish.clientlogformat", "{timestamp} | {host} | {status} | {latencyp} | {clientipp} | {methodp} | {path}", "The client log format string, created from available fields ({timestamp}, {host}, {status}, {latency}, {latencyp}, {clientip}, {clientipp, {method}, {methodp} and {path}) and delimiters. {latencyp}, {clientipp} and {methodp} are padded to deliver fixed column widths. {newline} will inject a newline")
 	clientLogFormatParts = []string{""}
 	idleTimeout          = flag.Int("sish.idletimeout", 5, "Number of seconds to wait for activity before closing a connection")
 	bannedSubdomainList  = []string{""}

--- a/main.go
+++ b/main.go
@@ -77,6 +77,7 @@ var (
 	versionCheck         = flag.Bool("sish.version", false, "Print version and exit")
 	tcpAlias             = flag.Bool("sish.tcpalias", false, "Whether or not to allow the use of TCP aliasing")
 	logToClient          = flag.Bool("sish.logtoclient", false, "Whether or not to log http requests to the client")
+	logDetail            = flag.Int("sish.logdetail", 3, "The request log detail level 0 is most compact, 3 is most verbose")
 	bannedSubdomainList  = []string{""}
 	filter               *ipfilter.IPFilter
 )

--- a/main.go
+++ b/main.go
@@ -11,6 +11,9 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"net/http"
+	"io/ioutil"
+	"bytes"
 
 	"github.com/jpillora/ipfilter"
 
@@ -79,6 +82,7 @@ var (
 	logToClient          = flag.Bool("sish.logtoclient", false, "Whether or not to log http requests to the client")
 	bannedSubdomainList  = []string{""}
 	filter               *ipfilter.IPFilter
+	serverIp             = ""
 )
 
 func main() {
@@ -151,6 +155,20 @@ func main() {
 	} else {
 		filter = ipfilter.NewNoDB(ipfilterOpts)
 	}
+
+
+	// Get this server's external IP
+	rsp, err := http.Get("http://checkip.amazonaws.com")
+	if err != nil {
+		log.Println("Couldn't get server's external IP", err)
+	}
+	defer rsp.Body.Close()
+	buf, err := ioutil.ReadAll(rsp.Body)
+	if err != nil {
+		log.Println("Couldn't get server's external IP", err)
+	}
+	serverIp = string(bytes.TrimSpace(buf))
+	log.Printf("This server's IP: %s", serverIp)
 
 	watchCerts()
 

--- a/main.go
+++ b/main.go
@@ -11,9 +11,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-	"net/http"
-	"io/ioutil"
-	"bytes"
 
 	"github.com/jpillora/ipfilter"
 
@@ -82,7 +79,6 @@ var (
 	logToClient          = flag.Bool("sish.logtoclient", false, "Whether or not to log http requests to the client")
 	bannedSubdomainList  = []string{""}
 	filter               *ipfilter.IPFilter
-	serverIp             = ""
 )
 
 func main() {
@@ -155,20 +151,6 @@ func main() {
 	} else {
 		filter = ipfilter.NewNoDB(ipfilterOpts)
 	}
-
-
-	// Get this server's external IP
-	rsp, err := http.Get("http://checkip.amazonaws.com")
-	if err != nil {
-		log.Println("Couldn't get server's external IP", err)
-	}
-	defer rsp.Body.Close()
-	buf, err := ioutil.ReadAll(rsp.Body)
-	if err != nil {
-		log.Println("Couldn't get server's external IP", err)
-	}
-	serverIp = string(bytes.TrimSpace(buf))
-	log.Printf("This server's IP: %s", serverIp)
 
 	watchCerts()
 

--- a/requests.go
+++ b/requests.go
@@ -135,7 +135,7 @@ func handleRemoteForward(newRequest *ssh.Request, sshConn *SSHConnection, state 
 		if *httpsEnabled {
 			httpsPortString := ""
 			if httpsPort != 443 {
-					httpsPortString = fmt.Sprintf(":%d", httpsPort)
+				httpsPortString = fmt.Sprintf(":%d", httpsPort)
 			}
 
 			requestMessages += aurora.Sprintf(aurora.Green("HTTP:  http://%s%s\r\n"), host, httpPortString)

--- a/requests.go
+++ b/requests.go
@@ -107,7 +107,7 @@ func handleRemoteForward(newRequest *ssh.Request, sshConn *SSHConnection, state 
 		connType = "https"
 	}
 
-	requestMessages := fmt.Sprintf("Starting SSH Fowarding service for %s. Forwarded connections can be accessed via the following methods:\r\n", aurora.Sprintf(aurora.Green("%s:%s"), connType, stringPort))
+	requestMessages := fmt.Sprintf("Forwarding %s traffic on port %s from:\r\n", connType, stringPort)
 
 	if stringPort == "80" || stringPort == "443" {
 		scheme := "http"
@@ -132,17 +132,19 @@ func handleRemoteForward(newRequest *ssh.Request, sshConn *SSHConnection, state 
 			httpPortString = fmt.Sprintf(":%d", httpPort)
 		}
 
-		requestMessages += fmt.Sprintf("%s: http://%s%s\r\n", aurora.BgBlue("HTTP"), host, httpPortString)
-		log.Printf("%s forwarding started: http://%s%s -> %s for client: %s\n", aurora.BgBlue("HTTP"), host, httpPortString, chanListener.Addr().String(), sshConn.SSHConn.RemoteAddr().String())
-
 		if *httpsEnabled {
 			httpsPortString := ""
 			if httpsPort != 443 {
-				httpsPortString = fmt.Sprintf(":%d", httpsPort)
+					httpsPortString = fmt.Sprintf(":%d", httpsPort)
 			}
 
-			requestMessages += fmt.Sprintf("%s: https://%s%s\r\n", aurora.BgBlue("HTTPS"), host, httpsPortString)
-			log.Printf("%s forwarding started: https://%s%s -> %s for client: %s\n", aurora.BgBlue("HTTPS"), host, httpPortString, chanListener.Addr().String(), sshConn.SSHConn.RemoteAddr().String())
+			requestMessages += aurora.Sprintf(aurora.Green("HTTP:  http://%s%s\r\n"), host, httpPortString)
+			requestMessages += aurora.Sprintf(aurora.Green("HTTPS: https://%s%s\r\n"), host, httpsPortString)
+			log.Printf("%s forwarding started: http://%s%s -> %s for client: %s\n", aurora.Green("HTTP"), host, httpPortString, chanListener.Addr().String(), sshConn.SSHConn.RemoteAddr().String())
+			log.Printf("%s forwarding started: https://%s%s -> %s for client: %s\n", aurora.Green("HTTPS"), host, httpPortString, chanListener.Addr().String(), sshConn.SSHConn.RemoteAddr().String())
+		} else {
+			requestMessages += aurora.Sprintf(aurora.Green("%s: %s%s\r\n"), "HTTP", host, httpPortString)
+			log.Printf("%s forwarding started: http://%s%s -> %s for client: %s\n", aurora.Green("HTTP"), host, httpPortString, chanListener.Addr().String(), sshConn.SSHConn.RemoteAddr().String())
 		}
 	} else {
 		if handleTCPAliasing {
@@ -151,11 +153,11 @@ func handleRemoteForward(newRequest *ssh.Request, sshConn *SSHConnection, state 
 			state.TCPListeners.Store(validAlias, chanListener.Addr().String())
 			defer state.TCPListeners.Delete(validAlias)
 
-			requestMessages += fmt.Sprintf("%s: %s\r\n", aurora.BgBlue("TCP Alias"), validAlias)
-			log.Printf("%s forwarding started: %s -> %s for client: %s\n", aurora.BgBlue("TCP Alias"), validAlias, chanListener.Addr().String(), sshConn.SSHConn.RemoteAddr().String())
+			requestMessages += fmt.Sprintf("%s: %s\r\n", aurora.Green("TCP Alias"), validAlias)
+			log.Printf("%s forwarding started: %s -> %s for client: %s\n", aurora.Green("TCP Alias"), validAlias, chanListener.Addr().String(), sshConn.SSHConn.RemoteAddr().String())
 		} else {
-			requestMessages += fmt.Sprintf("%s: %s:%d\r\n", aurora.BgBlue("TCP"), *rootDomain, chanListener.Addr().(*net.TCPAddr).Port)
-			log.Printf("%s forwarding started: %s:%d -> %s for client: %s\n", aurora.BgBlue("TCP"), *rootDomain, chanListener.Addr().(*net.TCPAddr).Port, chanListener.Addr().String(), sshConn.SSHConn.RemoteAddr().String())
+			requestMessages += fmt.Sprintf("%s: %s:%d\r\n", aurora.Green("TCP"), *rootDomain, chanListener.Addr().(*net.TCPAddr).Port)
+			log.Printf("%s forwarding started: %s:%d -> %s for client: %s\n", aurora.Green("TCP"), *rootDomain, chanListener.Addr().(*net.TCPAddr).Port, chanListener.Addr().String(), sshConn.SSHConn.RemoteAddr().String())
 		}
 	}
 


### PR DESCRIPTION
- Tidied up logs
- Trimmed down request latency
- Simplified colours
- Implemented blocking of requests to the server's IP (during testing a spambot started hammering me!) - using http://checkip.amazonaws.com at the moment, but could use another service or just use this as a fallback if it is not supplied as a parameter?