### PR TITLE
Make idle timeout configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ Usage of ./sish:
         The location of pem files for HTTPS (fullchain.pem and privkey.pem) (default "ssl/")
   -sish.httpsport int
         The port to use for https command output
+  -sish.idletimeout int
+        Number of seconds to wait for activity before closing a connection (default 5)
   -sish.keysdir string
         Directory for public keys for pubkey auth (default "pubkeys/")
   -sish.logtoclient

--- a/main.go
+++ b/main.go
@@ -77,6 +77,7 @@ var (
 	versionCheck         = flag.Bool("sish.version", false, "Print version and exit")
 	tcpAlias             = flag.Bool("sish.tcpalias", false, "Whether or not to allow the use of TCP aliasing")
 	logToClient          = flag.Bool("sish.logtoclient", false, "Whether or not to log http requests to the client")
+	idleTimeout          = flag.Int("sish.idletimeout", 5, "Number of seconds to wait for activity before closing a connection")
 	bannedSubdomainList  = []string{""}
 	filter               *ipfilter.IPFilter
 )

--- a/requests.go
+++ b/requests.go
@@ -239,7 +239,7 @@ type IdleTimeoutConn struct {
 
 // Read is needed to implement the reader part
 func (i IdleTimeoutConn) Read(buf []byte) (int, error) {
-	err := i.Conn.SetDeadline(time.Now().Add(*idleTimeout * time.Second))
+	err := i.Conn.SetDeadline(time.Now().Add(time.Duration(*idleTimeout) * time.Second))
 	if err != nil {
 		return 0, err
 	}
@@ -249,7 +249,7 @@ func (i IdleTimeoutConn) Read(buf []byte) (int, error) {
 
 // Write is needed to implement the writer part
 func (i IdleTimeoutConn) Write(buf []byte) (int, error) {
-	err := i.Conn.SetDeadline(time.Now().Add(*idleTimeout * time.Second))
+	err := i.Conn.SetDeadline(time.Now().Add(time.Duration(*idleTimeout) * time.Second))
 	if err != nil {
 		return 0, err
 	}

--- a/requests.go
+++ b/requests.go
@@ -239,7 +239,7 @@ type IdleTimeoutConn struct {
 
 // Read is needed to implement the reader part
 func (i IdleTimeoutConn) Read(buf []byte) (int, error) {
-	err := i.Conn.SetDeadline(time.Now().Add(5 * time.Second))
+	err := i.Conn.SetDeadline(time.Now().Add(*idleTimeout * time.Second))
 	if err != nil {
 		return 0, err
 	}
@@ -249,7 +249,7 @@ func (i IdleTimeoutConn) Read(buf []byte) (int, error) {
 
 // Write is needed to implement the writer part
 func (i IdleTimeoutConn) Write(buf []byte) (int, error) {
-	err := i.Conn.SetDeadline(time.Now().Add(5 * time.Second))
+	err := i.Conn.SetDeadline(time.Now().Add(*idleTimeout * time.Second))
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
The default of 5 seconds is too short for some clients, make it configurable so sish can support more varied use cases.

First, thanks for creating `sish`, it's wonderful! I'm currently using it to handle some Jenkins and 
 `jenkins-swarm` connections, which can be idle for longer than 5 seconds. There is a Jenkins-side setting I can tweak to make it send `PING` events more often, but doing that every 2 or 3 seconds to keep the connection alive seems like a waste. This change should maintain the current default behavior but make things more flexible for folks who need it.