### PR TITLE
fix: Load all keys from public key files

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -177,10 +177,9 @@ func loadCerts() {
 			}
 			return rest
 		}
-		rest := keyHandle(keyBytes, fileInfo)
 
-		if len(rest) > 0 {
-			keyHandle(rest, fileInfo)
+		for ok := true; ok; ok = len(keyBytes) > 0 {
+			keyBytes = keyHandle(keyBytes, fileInfo)
 		}
 	}
 


### PR DESCRIPTION
> The loadCerts function iterates only twice over the public key file and as such will only support a maximum of two keys per file.
> 
> The function should iterate over the file as long as new keys are found to support any amount of keys per file.

Fixes https://github.com/antoniomika/sish/issues/60