### PR TITLE
Added handling for an experienced panic condition of a channel being …

### DIFF
--- a/main.go
+++ b/main.go
@@ -356,8 +356,14 @@ func main() {
 
 // CleanUp closes all allocated resources and cleans them up
 func (s *SSHConnection) CleanUp(state *State) {
+	//Closing the channel has been observed to panic in some situations
+	// Example panic: panic: close of closed channel
+	// If this occurs treat the channel as closed and proceed to close the connection
+	defer func() {
+		recover()
+		s.SSHConn.Close()
+		state.SSHConnections.Delete(s.SSHConn.RemoteAddr())
+		log.Println("Closed SSH connection for:", s.SSHConn.RemoteAddr(), "user:", s.SSHConn.User())
+	}()
 	close(s.Close)
-	s.SSHConn.Close()
-	state.SSHConnections.Delete(s.SSHConn.RemoteAddr())
-	log.Println("Closed SSH connection for:", s.SSHConn.RemoteAddr(), "user:", s.SSHConn.User())
 }

--- a/main.go
+++ b/main.go
@@ -356,11 +356,13 @@ func main() {
 
 // CleanUp closes all allocated resources and cleans them up
 func (s *SSHConnection) CleanUp(state *State) {
-	//Closing the channel has been observed to panic in some situations
-	// Example panic: panic: close of closed channel
-	// If this occurs treat the channel as closed and proceed to close the connection
+	// Closing the channel has been observed to panic in some situations
+	//	Example panic: panic: close of closed channel
+	//	If this occurs treat the channel as closed and proceed to close the connection
 	defer func() {
-		recover()
+		if r := recover(); r != nil {
+			log.Println("Recovered from panic closing a channel")
+		}
 		s.SSHConn.Close()
 		state.SSHConnections.Delete(s.SSHConn.RemoteAddr())
 		log.Println("Closed SSH connection for:", s.SSHConn.RemoteAddr(), "user:", s.SSHConn.User())


### PR DESCRIPTION
During testing with frequent and fast client connections and disconnects a panic condition was experienced in the CleanUp function where an already closed channel was trying to be closed. This commit adds handling for this condition but doesn't address the root cause.

host1 sish: 2020/02/xx xx:xx:xx Closed SSH connection for: client.ip:39204 user: client.username
host1 sish: 2020/02/xx xx:xx:xx Waited for ssh conn without session: ssh: disconnect, reason 11: disconnected by user
host1 sish: panic: close of closed channel
host1 sish: goroutine 428 [running]:
host1 sish: main.(*SSHConnection).CleanUp(0xc000148900, 0xc000154f90)
host1 sish: /home/runner/work/sish/sish/main.go:333 +0x36
host1 sish: main.checkSession(0xc000148a40, 0xc000148900, 0xc000154f90)
host1 sish: /home/runner/work/sish/sish/handle.go:51 +0x185
host1 sish: created by main.handleRequest
host1 sish: /home/runner/work/sish/sish/handle.go:23 +0x1d5
