### PR TITLE
Add sish.connecttimeout setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ Usage of ./sish:
         The port to use for https command output
   -sish.idletimeout int
         Number of seconds to wait for activity before closing a connection (default 5)
+  -sish.connecttimeout int
+        Number of seconds the ssh login process is allowed before closing a connection (default 5)
   -sish.keysdir string
         Directory for public keys for pubkey auth (default "pubkeys/")
   -sish.logtoclient

--- a/main.go
+++ b/main.go
@@ -79,6 +79,7 @@ var (
 	tcpAlias              = flag.Bool("sish.tcpalias", false, "Whether or not to allow the use of TCP aliasing")
 	logToClient           = flag.Bool("sish.logtoclient", false, "Whether or not to log http requests to the client")
 	idleTimeout           = flag.Int("sish.idletimeout", 5, "Number of seconds to wait for activity before closing a connection")
+	connectTimeout        = flag.Int("sish.connecttimeout", 5, "Number of seconds the ssh login process is allowed before closing a connection")
 	appendUserToSubdomain = flag.Bool("sish.appendusertosubdomain", false, "Whether or not to append the user to the subdomain")
 	adminEnabled          = flag.Bool("sish.adminenabled", false, "Whether or not to enable the admin console")
 	adminToken            = flag.String("sish.admintoken", "S3Cr3tP4$$W0rD", "The token to use for admin access")
@@ -261,7 +262,7 @@ func main() {
 
 		if *cleanupUnbound {
 			go func() {
-				<-time.After(5 * time.Second)
+				<-time.After(time.Duration(*connectTimeout) * time.Second)
 				if !clientLoggedIn {
 					conn.Close()
 				}


### PR DESCRIPTION
I'm in a hotel now, with a really slow internet connection. I'm unable to connect to my sish instance because it takes around 4 seconds to prompt  me for my ssh pub key password. Once typed, 2 more seconds spent and the connection is dropped.

This PR adds a setting to configure this timeout. Unfortunately I don't have the tools with me to test this change and see if it fixes my issue.