### PR TITLE
[docs] clarify that sish.http(s)port flags are for overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Usage of ./sish:
   -sish.http string
         The address to listen for HTTP connections (default "localhost:80")
   -sish.httpport int
-        The port to use for http command output
+        Override the port used for HTTP connections
   -sish.https string
         The address to listen for HTTPS connections (default "localhost:443")
   -sish.httpsenabled
@@ -139,7 +139,7 @@ Usage of ./sish:
   -sish.httpspems string
         The location of pem files for HTTPS (fullchain.pem and privkey.pem) (default "ssl/")
   -sish.httpsport int
-        The port to use for https command output
+        Override the port used for HTTPS conections
   -sish.idletimeout int
         Number of seconds to wait for activity before closing a connection (default 5)
   -sish.keysdir string

--- a/main.go
+++ b/main.go
@@ -46,9 +46,9 @@ var (
 	httpsPort             int
 	serverAddr            = flag.String("sish.addr", "localhost:2222", "The address to listen for SSH connections")
 	httpAddr              = flag.String("sish.http", "localhost:80", "The address to listen for HTTP connections")
-	httpPortOverride      = flag.Int("sish.httpport", 0, "The port to use for http command output")
+	httpPortOverride      = flag.Int("sish.httpport", 0, "Override the port used for HTTP connections")
 	httpsAddr             = flag.String("sish.https", "localhost:443", "The address to listen for HTTPS connections")
-	httpsPortOverride     = flag.Int("sish.httpsport", 0, "The port to use for https command output")
+	httpsPortOverride     = flag.Int("sish.httpsport", 0, "Override the port used for HTTPS conections")
 	verifyOrigin          = flag.Bool("sish.verifyorigin", true, "Whether or not to verify origin on websocket connection")
 	verifySSL             = flag.Bool("sish.verifyssl", true, "Whether or not to verify SSL on proxy connection")
 	httpsEnabled          = flag.Bool("sish.httpsenabled", false, "Whether or not to listen for HTTPS connections")


### PR DESCRIPTION
the current documentation for the httpport and httpsport
flags are ambiguous and can mean that they can be used
without using http / https when the host can remain as
'localhost'.
This changeset clarifies the documentation to maintain
that the flags are only overrides to the default values
provided in the http / https flags.

Signed-off-by: shine <4771718+shinenelson@users.noreply.github.com>