### PR TITLE
docs: publish listening ports explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,10 @@ not built by default and will require a retag from a maintainer to be built.
         -v ~/sish/ssl:/ssl \
         -v ~/sish/keys:/keys \
         -v ~/sish/pubkeys:/pubkeys \
-        --net=host antoniomika/sish:latest \
+        --publish 22:22 \
+        --publish 80:80 \
+        --publish 443:443 \
+        antoniomika/sish:latest \
         --ssh-address=:22 \
         --http-address=:80 \
         --https-address=:443 \


### PR DESCRIPTION
Instead of using `--network=host` so that testing on macOS (and probably Windows) works. (the `host` option doesn't work on some systems--https://docs.docker.com/network/host/)

Final deploy target will probably be Linux, but this allows the command to work on more OSes I believe?