### PR TITLE
Fix: Send TCP Forward Request reply

### DIFF
--- a/sshmuxer/requests.go
+++ b/sshmuxer/requests.go
@@ -22,8 +22,8 @@ type channelForwardMsg struct {
 	Rport uint32
 }
 
-// forwardedTCPReplyPayload defines the reply to inform the client what port was actually assigned
-// https://tools.ietf.org/html/rfc4254#section-7.1
+// channelForwardReply defines the reply to inform the client what port was
+// actually assigned https://tools.ietf.org/html/rfc4254#section-7.1
 type channelForwardReply struct {
 	Rport uint32
 }
@@ -177,9 +177,14 @@ func handleRemoteForward(newRequest *ssh.Request, sshConn *utils.SSHConnection, 
 			return
 		}
 
-		//Reply that the session is successfully set up with the port that was assigned (which may be different than what was requested)
+		// reply that the session is successfully set up with the port that was
+		// assigned (which may be different than what was requested)
 		channelForwardReplyPayload := ssh.Marshal(channelForwardReply{bindPort})
-		newRequest.Reply(true, channelForwardReplyPayload)
+		err = newRequest.Reply(true, channelForwardReplyPayload)
+		if err != nil {
+			log.Println("Error replying to port forwarding request:", err)
+			return
+		}
 
 		mainRequestMessages = requestMessages
 

--- a/sshmuxer/requests.go
+++ b/sshmuxer/requests.go
@@ -22,6 +22,12 @@ type channelForwardMsg struct {
 	Rport uint32
 }
 
+// forwardedTCPReplyPayload defines the reply to inform the client what port was actually assigned
+// https://tools.ietf.org/html/rfc4254#section-7.1
+type channelForwardReply struct {
+	Rport uint32
+}
+
 // forwardedTCPPayload is the payload sent by SSH
 // to init a forwarded connection.
 type forwardedTCPPayload struct {
@@ -170,6 +176,10 @@ func handleRemoteForward(newRequest *ssh.Request, sshConn *utils.SSHConnection, 
 			}
 			return
 		}
+
+		//Reply that the session is successfully set up with the port that was assigned (which may be different than what was requested)
+		channelForwardReplyPayload := ssh.Marshal(channelForwardReply{bindPort})
+		newRequest.Reply(true, channelForwardReplyPayload)
 
 		mainRequestMessages = requestMessages
 


### PR DESCRIPTION
Continues the work of @JustinGrote.  Justin, feel free to cherry-pick this onto your branch if you like!  I also would like to use a golang ssh client, so it looks like an important change.

Closes #118 