### PR TITLE
Add possibility to specify the port in authorized keys

### DIFF
--- a/cmd/sish.go
+++ b/cmd/sish.go
@@ -77,6 +77,7 @@ func init() {
 	rootCmd.PersistentFlags().StringP("load-templates-directory", "", "templates/*", "The directory and glob parameter for templates that should be loaded")
 
 	rootCmd.PersistentFlags().BoolP("force-requested-ports", "", false, "Force the ports used to be the one that is requested. Will fail the bind if it exists already")
+	rootCmd.PersistentFlags().BoolP("use-ports-from-keys", "", false, "Ignore requested port and use the one specified as \"sishport\" option with the user's pubkey, if exists.")
 	rootCmd.PersistentFlags().BoolP("force-requested-aliases", "", false, "Force the aliases used to be the one that is requested. Will fail the bind if it exists already")
 	rootCmd.PersistentFlags().BoolP("force-requested-subdomains", "", false, "Force the subdomains used to be the one that is requested. Will fail the bind if it exists already")
 	rootCmd.PersistentFlags().BoolP("bind-random-subdomains", "", true, "Force bound HTTP tunnels to use random subdomains instead of user provided ones")

--- a/sshmuxer/requests.go
+++ b/sshmuxer/requests.go
@@ -179,6 +179,7 @@ func handleRemoteForward(newRequest *ssh.Request, sshConn *utils.SSHConnection, 
 			if err != nil {
 				log.Println("Error replying to socket request:", err)
 			}
+
 			return
 		}
 

--- a/sshmuxer/tcphandler.go
+++ b/sshmuxer/tcphandler.go
@@ -25,6 +25,10 @@ func handleTCPListener(check *channelForwardMsg, bindPort uint32, requestMessage
 		return nil, nil, "", "", fmt.Errorf("Error assigning requested port to tunnel")
 	}
 
+	if tcpPort == 0 {
+		return nil, nil, "", "", fmt.Errorf("Error! There is no port to be binded for this particular user")
+	}
+
 	if tH == nil {
 		lb, err := roundrobin.New(nil)
 


### PR DESCRIPTION
If switch 
```--use-ports-from-keys```
is enabled, only and only the port that is specified with the user's key as option sishport can be assigned

I will check the check