### PR TITLE
Fix templates not being included into the release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -38,3 +38,4 @@ archives:
       - README*
       - deploy/**/*
       - templates/*
+      - templates/**/*

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -37,4 +37,4 @@ archives:
       - LICENSE*
       - README*
       - deploy/**/*
-      - templates/**/*
+      - templates/*


### PR DESCRIPTION
I found out that the templates folder wasn't being included, which is inconvenient, but it actually seems like it should have been included.

The issue I found is that `templates/**/*` doesn't match the files directly inside templates, it should be just `template/*`.

I tested it with `goreleaser release --snapshot` and seems to work perfectly.
Let me know what you think.