### PR TITLE
Fix on demand cert issuing

### DIFF
--- a/httpmuxer/httpmuxer.go
+++ b/httpmuxer/httpmuxer.go
@@ -272,6 +272,8 @@ func Start(state *utils.State) {
 		gin.WrapH(currentListener.Balancer)(c)
 	})
 
+	var acmeIssuer *certmagic.ACMEIssuer = nil
+
 	// If HTTPS is enabled, setup certmagic to allow us to provision HTTPS certs on the fly.
 	// You can use sish without a wildcard cert, but you really should. If you get a lot of clients
 	// with many random subdomains, you'll burn through your Let's Encrypt quota. Be careful!
@@ -282,7 +284,7 @@ func Start(state *utils.State) {
 
 		certManager := certmagic.NewDefault()
 
-		acmeIssuer := certmagic.NewACMEIssuer(certManager, certmagic.DefaultACME)
+		acmeIssuer = certmagic.NewACMEIssuer(certManager, certmagic.DefaultACME)
 
 		acmeIssuer.Agreed = viper.GetBool("https-ondemand-certificate-accept-terms")
 		acmeIssuer.Email = viper.GetString("https-ondemand-certificate-email")
@@ -396,6 +398,9 @@ func Start(state *utils.State) {
 	httpServer := &http.Server{
 		Addr:    viper.GetString("http-address"),
 		Handler: r,
+	}
+	if acmeIssuer != nil {
+		httpServer.Handler = acmeIssuer.HTTPChallengeHandler(r)
 	}
 
 	var httpListener net.Listener


### PR DESCRIPTION
The onDemand issuing was not working cause requests to /.well-known/ were redirected to the client.
Wrapping a handler with challenge handler solved the problem for me.