### PR TITLE
feat: wildcard support

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -273,7 +273,6 @@ github.com/subosito/gotenv v1.4.1 h1:jyEFiXpy21Wm81FBN71l9VoMMV8H8jG+qIK3GCpY6Qs
 github.com/subosito/gotenv v1.4.1/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=
 github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce h1:fb190+cK2Xz/dvi9Hv8eCYJYvIGUTN2/KLq1pT6CjEc=
 github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoik09Xen7gje4m9ERNah1d1PPsVq1VEx9vE4=
-github.com/ugorji/go v1.2.7 h1:qYhyWUUd6WbiM+C6JZAUkIJt/1WrjzNHY9+KCIjVqTo=
 github.com/ugorji/go v1.2.7/go.mod h1:nF9osbDWLy6bDVv/Rtoh6QgnvNDpmCalQV5urGCCS6M=
 github.com/ugorji/go/codec v1.2.7 h1:YPXUKf7fYbp/y8xloBqZOw2qaVggbfwMlI8WM3wZUJ0=
 github.com/ugorji/go/codec v1.2.7/go.mod h1:WGN1fab3R1fzQlVQTkfxVtIBhWDRqOviHU95kRgeqEY=

--- a/httpmuxer/httpmuxer.go
+++ b/httpmuxer/httpmuxer.go
@@ -193,6 +193,17 @@ func Start(state *utils.State) {
 
 		if currentListener == nil {
 			state.HTTPListeners.Range(func(key string, locationListener *utils.HTTPHolder) bool {
+				checkHost := locationListener.HTTPUrl.Host
+				wildcard := false
+				if strings.HasPrefix(locationListener.HTTPUrl.Host, "*.") {
+					checkHost = checkHost[1:]
+					wildcard = true
+				}
+				if wildcard && strings.HasSuffix(hostname, checkHost) {
+					currentListener = locationListener
+					authNeeded = false
+					return false
+				}
 				if hostname == locationListener.HTTPUrl.Host && strings.HasPrefix(c.Request.URL.Path, locationListener.HTTPUrl.Path) {
 					currentListener = locationListener
 					authNeeded = false
@@ -339,6 +350,16 @@ func Start(state *utils.State) {
 				ok := false
 
 				state.HTTPListeners.Range(func(key string, locationListener *utils.HTTPHolder) bool {
+					checkHost := locationListener.HTTPUrl.Host
+					wildcard := false
+					if strings.HasPrefix(locationListener.HTTPUrl.Host, "*.") {
+						checkHost = checkHost[1:]
+						wildcard = true
+					}
+					if wildcard && strings.HasSuffix(name, checkHost) {
+						ok = true
+						return false
+					}
 					if name == locationListener.HTTPUrl.Host {
 						ok = true
 						return false


### PR DESCRIPTION
Now, you can use command like:

ssh -R '*.a':80:localhost:3000 ssi.sh 

Then users can access your website with smth like: http(s)://any.a.ssi.sh  http(s)://anyb.a.ssi.sh 