### PR TITLE
Add password authentication request validation

### DIFF
--- a/cmd/sish.go
+++ b/cmd/sish.go
@@ -150,6 +150,8 @@ func init() {
 	rootCmd.PersistentFlags().DurationP("authentication-keys-directory-watch-interval", "", 200*time.Millisecond, "The interval to poll for filesystem changes for SSH keys")
 	rootCmd.PersistentFlags().DurationP("https-certificate-directory-watch-interval", "", 200*time.Millisecond, "The interval to poll for filesystem changes for HTTPS certificates")
 	rootCmd.PersistentFlags().DurationP("authentication-key-request-timeout", "", 5*time.Second, "Duration to wait for a response from the authentication key request")
+	rootCmd.PersistentFlags().StringP("authentication-password-request-url", "", "", "A url to validate passwords for password-based authentication.\nsish will make an HTTP POST request to this URL with a JSON body containing\nthe provided password, username, and ip address. E.g.:\n{\"password\": string, \"user\": string, \"remote_addr\": string}\nA response with status code 200 indicates approval of the password")
+	rootCmd.PersistentFlags().DurationP("authentication-password-request-timeout", "", 5*time.Second, "Duration to wait for a response from the authentication password request")
 }
 
 // initConfig initializes the configuration and loads needed

--- a/config.example.yml
+++ b/config.example.yml
@@ -9,6 +9,8 @@ authentication-key-request-url: ""
 authentication-keys-directory: deploy/pubkeys/
 authentication-keys-directory-watch-interval: 200ms
 authentication-password: ""
+authentication-password-request-url: ""
+authentication-password-request-timeout: 5s
 banned-aliases: ""
 banned-countries: ""
 banned-ips: ""

--- a/docs/posts/cli.md
+++ b/docs/posts/cli.md
@@ -5,7 +5,6 @@ keywords: [sish, cli]
 ---
 
 ```text
-```text
 sish is a command line utility that implements an SSH server that can handle HTTP(S)/WS(S)/TCP multiplexing, forwarding and load balancing.
 It can handle multiple vhosting and reverse tunneling endpoints for a large number of clients.
 
@@ -31,6 +30,12 @@ Flags:
                                                                 from the authentication list (default "deploy/pubkeys/")
       --authentication-keys-directory-watch-interval duration   The interval to poll for filesystem changes for SSH keys (default 200ms)
   -u, --authentication-password string                          Password to use for SSH server password authentication
+      --authentication-password-request-timeout duration        Duration to wait for a response from the authentication password request (default 5s)
+      --authentication-password-request-url string              A url to validate passwords for password-based authentication.
+                                                                sish will make an HTTP POST request to this URL with a JSON body containing
+                                                                the provided password, username, and ip address. E.g.:
+                                                                {"password": string, "user": string, "remote_addr": string}
+                                                                A response with status code 200 indicates approval of the password
       --banned-aliases string                                   A comma separated list of banned aliases that users are unable to bind
   -o, --banned-countries string                                 A comma separated list of banned countries. Applies to HTTP, TCP, and SSH connections
   -x, --banned-ips string                                       A comma separated list of banned ips that are unable to access the service. Applies to HTTP, TCP, and SSH connections
@@ -126,5 +131,4 @@ Flags:
   -v, --version                                                 version for sish
   -y, --whitelisted-countries string                            A comma separated list of whitelisted countries. Applies to HTTP, TCP, and SSH connections
   -w, --whitelisted-ips string                                  A comma separated list of whitelisted ips. Applies to HTTP, TCP, and SSH connections
-```
 ```


### PR DESCRIPTION
This adds a password-based authentication mechanism under the option `--authentication-password-request-url`, which functions similarly to `--authentication-key-request-url`, but takes a password instead of a public key.

Closes #322