### PR TITLE
Disable password authentification on empty password

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -517,6 +517,10 @@ func GetSSHConfig() *ssh.ServerConfig {
 		},
 	}
 
+	if viper.GetString("authentication-password") == "" && viper.GetString("authentication-password-request-url") == "" {
+		sshConfig.PasswordCallback = nil
+	}
+
 	loadPrivateKeys(sshConfig)
 
 	return sshConfig


### PR DESCRIPTION
If no password is set, disable password authentification completely by setting an empty password callback function. This prevents brute force attacks guessing the password and hence reduces server load and log amount.