### PR TITLE
Make welcome message configurable

### DIFF
--- a/cmd/sish.go
+++ b/cmd/sish.go
@@ -78,6 +78,7 @@ func init() {
 	rootCmd.PersistentFlags().StringP("log-to-file-path", "", "/tmp/sish.log", "The file to write log output to")
 	rootCmd.PersistentFlags().StringP("bind-hosts", "", "", "A comma separated list of other hosts a user can bind. Requested hosts should be subdomains of a host in this list")
 	rootCmd.PersistentFlags().StringP("load-templates-directory", "", "templates/*", "The directory and glob parameter for templates that should be loaded")
+	rootCmd.PersistentFlags().StringP("welcome-message", "", "Press Ctrl-C to close the session.", "Message displayed to users upon connection")
 
 	rootCmd.PersistentFlags().BoolP("force-requested-ports", "", false, "Force the ports used to be the one that is requested. Will fail the bind if it exists already")
 	rootCmd.PersistentFlags().BoolP("force-requested-aliases", "", false, "Force the aliases used to be the one that is requested. Will fail the bind if it exists already")

--- a/config.example.yml
+++ b/config.example.yml
@@ -97,5 +97,6 @@ tcp-load-balancer: false
 time-format: 2006/01/02 - 15:04:05
 verify-dns: true
 verify-ssl: true
+welcome-message: "Press Ctrl-C to close the session."
 whitelisted-countries: ""
 whitelisted-ips: ""

--- a/sshmuxer/channels.go
+++ b/sshmuxer/channels.go
@@ -73,7 +73,10 @@ func handleSession(newChannel ssh.NewChannel, sshConn *utils.SSHConnection, stat
 		log.Println("Handling session for connection:", connection)
 	}
 
-	writeToSession(connection, aurora.BgRed("Press Ctrl-C to close the session.").String()+"\r\n")
+	welcomeMessage := viper.GetString("welcome-message")
+	if welcomeMessage != "" {
+		writeToSession(connection, aurora.BgRed(welcomeMessage).String()+"\r\n")
+	}
 
 	go func() {
 		for {


### PR DESCRIPTION
The message displayed to the user upon connection (which used to be a hard-coded "Press Ctrl-C to close the session.") can now be configured using the "welcome-message" setting in the config file or the "--welcome-message" command line argument. The default value is the beforementioned message, so without an explicit configuration the behavior will be the same as before.

Fixes #341