### PR TITLE
Add proxy-ssl-termination option

### DIFF
--- a/cmd/sish.go
+++ b/cmd/sish.go
@@ -99,6 +99,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolP("proxy-protocol", "", false, "Use the proxy-protocol while proxying connections in order to pass-on IP address and port information")
 	rootCmd.PersistentFlags().BoolP("proxy-protocol-use-timeout", "", false, "Use a timeout for the proxy-protocol read")
 	rootCmd.PersistentFlags().BoolP("proxy-protocol-listener", "", false, "Use the proxy-protocol to resolve ip addresses from user connections")
+	rootCmd.PersistentFlags().BoolP("proxy-ssl-termination", "", false, "Whether sish is running behind an SSL-terminated reverse proxy\nIf true, the displayed HTTP URL will use `https://` despite running on port 80")
 	rootCmd.PersistentFlags().BoolP("https", "", false, "Listen for HTTPS connections. Requires a correct --https-certificate-directory")
 	rootCmd.PersistentFlags().BoolP("force-all-https", "", false, "Redirect all requests to the https server")
 	rootCmd.PersistentFlags().BoolP("force-https", "", false, "Allow indiviual binds to request for https to be enforced")

--- a/config.example.yml
+++ b/config.example.yml
@@ -79,6 +79,7 @@ proxy-protocol-policy: use
 proxy-protocol-timeout: 200ms
 proxy-protocol-use-timeout: false
 proxy-protocol-version: "1"
+proxy-ssl-termination: false
 redirect-root: true
 redirect-root-location: https://github.com/antoniomika/sish
 rewrite-host-header: true

--- a/docs/posts/cli.md
+++ b/docs/posts/cli.md
@@ -1,6 +1,6 @@
 ---
 title: CLI
-description: How use sish's CLI 
+description: How use sish's CLI
 keywords: [sish, cli]
 ---
 
@@ -107,6 +107,7 @@ Flags:
       --proxy-protocol-use-timeout                              Use a timeout for the proxy-protocol read
   -q, --proxy-protocol-version string                           What version of the proxy protocol to use. Can either be 1, 2, or userdefined.
                                                                 If userdefined, the user needs to add a command to SSH called proxyproto=version (ie proxyproto=1) (default "1")
+      --proxy-ssl-termination                                   Whether sish is running behind an SSL terminated reverse proxy
       --redirect-root                                           Redirect the root domain to the location defined in --redirect-root-location (default true)
   -r, --redirect-root-location string                           The location to redirect requests to the root domain
                                                                 to instead of responding with a 404 (default "https://github.com/antoniomika/sish")
@@ -129,6 +130,7 @@ Flags:
       --verify-dns                                              Verify DNS information for hosts and ensure it matches a connecting users sha256 key fingerprint (default true)
       --verify-ssl                                              Verify SSL certificates made on proxied HTTP connections (default true)
   -v, --version                                                 version for sish
+      --welcome-message string                                  Message displayed to users upon connection (default "Press Ctrl-C to close the session.")
   -y, --whitelisted-countries string                            A comma separated list of whitelisted countries. Applies to HTTP, TCP, and SSH connections
   -w, --whitelisted-ips string                                  A comma separated list of whitelisted ips. Applies to HTTP, TCP, and SSH connections
 ```

--- a/sshmuxer/httphandler.go
+++ b/sshmuxer/httphandler.go
@@ -121,16 +121,17 @@ func handleHTTPListener(check *channelForwardMsg, _ string, requestMessages stri
 		}
 	}
 
-	httpPortString := ""
-	if state.Ports.HTTPPort != 80 {
-		httpPortString = fmt.Sprintf(":%d", state.Ports.HTTPPort)
+	if !viper.GetBool("proxy-ssl-termination") {
+		httpPortString := ""
+		if state.Ports.HTTPPort != 80 {
+			httpPortString = fmt.Sprintf(":%d", state.Ports.HTTPPort)
+		}
+
+		requestMessages += fmt.Sprintf("%s: http://%s%s%s%s\r\n", aurora.BgBlue("HTTP"), userPass, pH.HTTPUrl.Host, httpPortString, pH.HTTPUrl.Path)
+		log.Printf("%s forwarding started: http://%s%s%s%s -> %s for client: %s\n", aurora.BgBlue("HTTP"), userPass, pH.HTTPUrl.Host, httpPortString, pH.HTTPUrl.Path, listenerHolder.Addr().String(), sshConn.SSHConn.RemoteAddr().String())
 	}
 
-	requestMessages += fmt.Sprintf("%s: http://%s%s%s%s\r\n", aurora.BgBlue("HTTP"), userPass, pH.HTTPUrl.Host, httpPortString, pH.HTTPUrl.Path)
-
-	log.Printf("%s forwarding started: http://%s%s%s%s -> %s for client: %s\n", aurora.BgBlue("HTTP"), userPass, pH.HTTPUrl.Host, httpPortString, pH.HTTPUrl.Path, listenerHolder.Addr().String(), sshConn.SSHConn.RemoteAddr().String())
-
-	if viper.GetBool("https") {
+	if viper.GetBool("https") || viper.GetBool("proxy-ssl-termination") {
 		httpsPortString := ""
 		if state.Ports.HTTPSPort != 443 {
 			httpsPortString = fmt.Sprintf(":%d", state.Ports.HTTPSPort)


### PR DESCRIPTION
Can be used when sish runs behind a reverse proxy to display HTTPS URLs despite running on the HTTP port