### PR TITLE
fix: update GoReleaser configurations

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -34,7 +34,8 @@ archives:
     wrap_in_directory: true
     format_overrides:
       - goos: windows
-        format: zip
+        formats:
+          - zip
     files:
       - LICENSE*
       - README*


### PR DESCRIPTION
## PR Summary
This small PR updates the GoReleaser configuration to resolve the following warnings which you can find in the [CI logs](https://github.com/antoniomika/sish/actions/runs/15231881715/job/42840635238#step:4:25): 
```
DEPRECATED:  archives.format  should not be used anymore, check https://goreleaser.com/deprecations#archivesformat for more info
```