### PR TITLE
fix: clean up forwarding when an SSH connection drops during setup

### DIFF
--- a/sshmuxer/handle_test.go
+++ b/sshmuxer/handle_test.go
@@ -1,0 +1,141 @@
+package sshmuxer
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/antoniomika/sish/utils"
+	"github.com/spf13/viper"
+	"golang.org/x/crypto/ssh"
+)
+
+// dropConnAfterForwardRequest connects to addr, requests an HTTP remote
+// forward for the given subdomain without waiting for the reply, and then
+// yanks the TCP connection. The drop happens inside the server's 1s Exec
+// fallback window (see handleRemoteForward), so the server ends up building
+// the forward after the connection is already gone - the condition that a
+// flaky network triggers in the wild.
+func dropConnAfterForwardRequest(t *testing.T, addr, subdomain string) {
+	t.Helper()
+
+	netConn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+
+	clientConfig := &ssh.ClientConfig{
+		User:            "tester",
+		Auth:            []ssh.AuthMethod{ssh.Password("")},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	}
+
+	conn, chans, reqs, err := ssh.NewClientConn(netConn, addr, clientConfig)
+	if err != nil {
+		netConn.Close()
+		t.Fatalf("ssh handshake: %v", err)
+	}
+
+	go ssh.DiscardRequests(reqs)
+	go func() {
+		for nc := range chans {
+			_ = nc.Reject(ssh.Prohibited, "no channels")
+		}
+	}()
+
+	// Fire the forward request but never wait for its reply.
+	go func() {
+		_, _, _ = conn.SendRequest("tcpip-forward", true,
+			ssh.Marshal(&channelForwardMsg{Addr: subdomain, Rport: 80}))
+	}()
+
+	// Give the request a moment to reach the server, then drop the connection.
+	time.Sleep(30 * time.Millisecond)
+	netConn.Close()
+}
+
+func countHTTPListeners(state *utils.State) int {
+	count := 0
+	state.HTTPListeners.Range(func(_ string, _ *utils.HTTPHolder) bool {
+		count++
+		return true
+	})
+	return count
+}
+
+// TestForwardingCleanupOnDroppedConn verifies that connections dropped right
+// after requesting a forward do not leave behind HTTP forwarding routes. A
+// leaked route keeps its subdomain permanently reserved (and is a data race on
+// the deferred cleanup handler, which -race flags), so a clean run must end
+// with zero HTTP listeners registered.
+func TestForwardingCleanupOnDroppedConn(t *testing.T) {
+	dir, err := os.MkdirTemp("", "sish_keys")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	viper.Set("private-keys-directory", dir)
+	viper.Set("authentication", false)
+	viper.Set("domain", "localhost")
+	viper.Set("bind-random-subdomains", false)
+	viper.Set("cleanup-unauthed", false)
+	viper.Set("ping-client", false)
+	viper.Set("idle-connection", false)
+
+	utils.Setup(io.Discard)
+
+	// Silence the per-connection logging this test deliberately generates.
+	log.SetOutput(io.Discard)
+	defer log.SetOutput(os.Stderr)
+
+	sshConfig := utils.GetSSHConfig()
+	state := utils.NewState()
+
+	listener, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			go handleConn(conn, state, sshConfig)
+		}
+	}()
+
+	addr := listener.Addr().String()
+
+	// Each unique subdomain registers an independent HTTP route, so any leak
+	// is observable. Repeat enough to reliably lose the cleanup race.
+	const numConns = 40
+	for i := 0; i < numConns; i++ {
+		dropConnAfterForwardRequest(t, addr, fmt.Sprintf("tun%d", i))
+	}
+
+	// Every dropped connection builds its forward ~1s later (the Exec
+	// fallback) and should immediately tear it down again because the
+	// connection is gone. Wait past that window, then require the route table
+	// to drain to zero.
+	time.Sleep(2500 * time.Millisecond)
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		remaining := countHTTPListeners(state)
+		if remaining == 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("%d HTTP forwarding route(s) leaked: connections dropped before forwarding completed left their subdomains permanently reserved", remaining)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}

--- a/sshmuxer/handle_test.go
+++ b/sshmuxer/handle_test.go
@@ -1,11 +1,14 @@
 package sshmuxer
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"log"
 	"net"
 	"os"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -13,6 +16,25 @@ import (
 	"github.com/spf13/viper"
 	"golang.org/x/crypto/ssh"
 )
+
+// syncBuffer is a goroutine-safe buffer for capturing log output written
+// concurrently by the server goroutines under test.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
 
 // dropConnAfterForwardRequest connects to addr, requests an HTTP remote
 // forward for the given subdomain without waiting for the reply, and then
@@ -137,5 +159,95 @@ func TestForwardingCleanupOnDroppedConn(t *testing.T) {
 			t.Fatalf("%d HTTP forwarding route(s) leaked: connections dropped before forwarding completed left their subdomains permanently reserved", remaining)
 		}
 		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+// TestForwardingStoppedIsLogged verifies that tearing down an established
+// forward emits a "forwarding stopped" log line, mirroring the
+// "forwarding started" log.
+func TestForwardingStoppedIsLogged(t *testing.T) {
+	dir, err := os.MkdirTemp("", "sish_keys")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	viper.Set("private-keys-directory", dir)
+	viper.Set("authentication", false)
+	viper.Set("domain", "localhost")
+	viper.Set("bind-random-subdomains", false)
+	viper.Set("cleanup-unauthed", false)
+	viper.Set("ping-client", false)
+	viper.Set("idle-connection", false)
+
+	utils.Setup(io.Discard)
+
+	logBuf := &syncBuffer{}
+	log.SetOutput(logBuf)
+	defer log.SetOutput(os.Stderr)
+
+	sshConfig := utils.GetSSHConfig()
+	state := utils.NewState()
+
+	listener, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			go handleConn(conn, state, sshConfig)
+		}
+	}()
+
+	addr := listener.Addr().String()
+
+	netConn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+
+	conn, chans, reqs, err := ssh.NewClientConn(netConn, addr, &ssh.ClientConfig{
+		User:            "tester",
+		Auth:            []ssh.AuthMethod{ssh.Password("")},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+	})
+	if err != nil {
+		netConn.Close()
+		t.Fatalf("ssh handshake: %v", err)
+	}
+
+	go ssh.DiscardRequests(reqs)
+	go func() {
+		for nc := range chans {
+			_ = nc.Reject(ssh.Prohibited, "no channels")
+		}
+	}()
+
+	// Request the forward and wait for the reply: once it returns the server
+	// has established the forward ("forwarding started" is logged).
+	ok, _, err := conn.SendRequest("tcpip-forward", true,
+		ssh.Marshal(&channelForwardMsg{Addr: "stoptest", Rport: 80}))
+	if err != nil || !ok {
+		t.Fatalf("forward request not accepted: ok=%v err=%v", ok, err)
+	}
+
+	// Tear the forward down by closing the connection.
+	netConn.Close()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if strings.Contains(logBuf.String(), "forwarding stopped") {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("expected a \"forwarding stopped\" log after the connection closed; got:\n%s", logBuf.String())
+		}
+		time.Sleep(50 * time.Millisecond)
 	}
 }

--- a/sshmuxer/requests.go
+++ b/sshmuxer/requests.go
@@ -217,12 +217,23 @@ func handleRemoteForward(newRequest *ssh.Request, sshConn *utils.SSHConnection, 
 
 	deferHandler := func() {}
 
+	// Set once a forward is actually established (see the switch below); used
+	// to log when it is later torn down, mirroring the "forwarding started"
+	// logs. Left empty for setups that never completed, so we don't log a stop
+	// for a forward that never started.
+	forwardingType := ""
+	forwardingName := ""
+
 	cleanupChanListener := func() {
 		listenerHolder.Close()
 		state.Listeners.Delete(listenAddr)
 		sshConn.Listeners.Delete(listenAddr)
 		os.Remove(listenAddr)
 		deferHandler()
+
+		if forwardingType != "" {
+			log.Printf("%s forwarding stopped: %s -> %s for client: %s\n", aurora.BgBlue(forwardingType), forwardingName, listenAddr, sshConn.SSHConn.RemoteAddr().String())
+		}
 	}
 
 	connType := "tcp"
@@ -255,6 +266,9 @@ func handleRemoteForward(newRequest *ssh.Request, sshConn *utils.SSHConnection, 
 		}
 
 		mainRequestMessages = requestMessages
+
+		forwardingType = strings.ToUpper(connType)
+		forwardingName = pH.HTTPUrl.String()
 
 		deferHandler = func() {
 			err := pH.Balancer.RemoveServer(serverURL)
@@ -289,6 +303,9 @@ func handleRemoteForward(newRequest *ssh.Request, sshConn *utils.SSHConnection, 
 
 		mainRequestMessages = requestMessages
 
+		forwardingType = "TCP Alias"
+		forwardingName = validAlias
+
 		deferHandler = func() {
 			err := aH.Balancer.RemoveServer(serverURL)
 			if err != nil {
@@ -319,6 +336,9 @@ func handleRemoteForward(newRequest *ssh.Request, sshConn *utils.SSHConnection, 
 		portChannelForwardReplyPayload.Rport = uint32(tH.Listener.Addr().(*multilistener.MultiListener).Addresses()[0].(*net.TCPAddr).Port)
 
 		mainRequestMessages = requestMessages
+
+		forwardingType = strings.ToUpper(connType)
+		forwardingName = tcpAddr
 
 		if !tH.NoHandle {
 			go tH.Handle(state)

--- a/sshmuxer/requests.go
+++ b/sshmuxer/requests.go
@@ -95,11 +95,24 @@ func handleCancelRemoteForward(newRequest *ssh.Request, sshConn *utils.SSHConnec
 func handleRemoteForward(newRequest *ssh.Request, sshConn *utils.SSHConnection, state *utils.State) {
 	select {
 	case <-sshConn.Exec:
+	case <-sshConn.Close:
 	case <-time.After(1 * time.Second):
-		break
 	}
 
 	cleanupOnce := &sync.Once{}
+
+	// If the connection was torn down while we waited above (for example, the
+	// client dropped right after requesting the forward), don't stand up any
+	// forwarding for it: doing so would reserve the address for a dead session.
+	select {
+	case <-sshConn.Close:
+		if err := newRequest.Reply(false, nil); err != nil {
+			log.Println("Error replying to socket request:", err)
+		}
+		return
+	default:
+	}
+
 	check := &channelForwardMsg{}
 
 	err := ssh.Unmarshal(newRequest.Payload, check)
@@ -211,11 +224,6 @@ func handleRemoteForward(newRequest *ssh.Request, sshConn *utils.SSHConnection, 
 		os.Remove(listenAddr)
 		deferHandler()
 	}
-
-	go func() {
-		<-sshConn.Close
-		cleanupOnce.Do(cleanupChanListener)
-	}()
 
 	connType := "tcp"
 	if sniProxyForced {
@@ -342,6 +350,16 @@ func handleRemoteForward(newRequest *ssh.Request, sshConn *utils.SSHConnection, 
 		}
 	}
 
+	// Only now that deferHandler has been assigned by the switch above do we
+	// start watching for connection teardown. Wiring this up earlier races
+	// with that assignment and can run cleanup against the no-op handler,
+	// leaking the registered route. If the connection already closed during
+	// setup, this fires immediately and tears everything back down.
+	go func() {
+		<-sshConn.Close
+		cleanupOnce.Do(cleanupChanListener)
+	}()
+
 	if check.Rport != 0 {
 		portChannelForwardReplyPayload.Rport = check.Rport
 	}
@@ -349,6 +367,7 @@ func handleRemoteForward(newRequest *ssh.Request, sshConn *utils.SSHConnection, 
 	err = newRequest.Reply(true, ssh.Marshal(portChannelForwardReplyPayload))
 	if err != nil {
 		log.Println("Error replying to port forwarding request:", err)
+		cleanupOnce.Do(cleanupChanListener)
 		return
 	}
 

--- a/sshmuxer/sshmuxer.go
+++ b/sshmuxer/sshmuxer.go
@@ -201,131 +201,134 @@ func Start() {
 			continue
 		}
 
-		clientRemote, _, err := net.SplitHostPort(conn.RemoteAddr().String())
+		go handleConn(conn, state, sshConfig)
+	}
+}
 
-		if err != nil || state.IPFilter.Blocked(clientRemote) {
-			conn.Close()
-			continue
-		}
+// handleConn handles a single accepted SSH connection: it performs the SSH
+// handshake and wires up the per-connection goroutines (cleanup on close,
+// request/channel handling, unbound cleanup and keepalives). It is split out
+// of Start so the connection lifecycle can be exercised by tests.
+func handleConn(conn net.Conn, state *utils.State, sshConfig *ssh.ServerConfig) {
+	clientRemote, _, err := net.SplitHostPort(conn.RemoteAddr().String())
 
-		clientLoggedInMutex := &sync.Mutex{}
+	if err != nil || state.IPFilter.Blocked(clientRemote) {
+		conn.Close()
+		return
+	}
 
-		clientLoggedInMutex.Lock()
-		clientLoggedIn := false
-		clientLoggedInMutex.Unlock()
+	clientLoggedInMutex := &sync.Mutex{}
+	clientLoggedIn := false
 
-		if viper.GetBool("cleanup-unauthed") {
-			go func() {
-				<-time.After(viper.GetDuration("cleanup-unauthed-timeout"))
-				clientLoggedInMutex.Lock()
-				if !clientLoggedIn {
-					conn.Close()
-				}
-				clientLoggedInMutex.Unlock()
-			}()
-		}
-
-		log.Println("Accepted SSH connection for:", conn.RemoteAddr())
-
+	if viper.GetBool("cleanup-unauthed") {
 		go func() {
-			sshConn, chans, reqs, err := ssh.NewServerConn(conn, sshConfig)
+			<-time.After(viper.GetDuration("cleanup-unauthed-timeout"))
 			clientLoggedInMutex.Lock()
-			clientLoggedIn = true
-			clientLoggedInMutex.Unlock()
-			if err != nil {
+			if !clientLoggedIn {
 				conn.Close()
-				log.Println(err)
-				return
 			}
+			clientLoggedInMutex.Unlock()
+		}()
+	}
 
-			pubKeyFingerprint := ""
+	log.Println("Accepted SSH connection for:", conn.RemoteAddr())
 
-			if sshConn.Permissions != nil {
-				if _, ok := sshConn.Permissions.Extensions["pubKey"]; ok {
-					pubKeyFingerprint = sshConn.Permissions.Extensions["pubKeyFingerprint"]
-				}
-			}
+	sshConn, chans, reqs, err := ssh.NewServerConn(conn, sshConfig)
+	clientLoggedInMutex.Lock()
+	clientLoggedIn = true
+	clientLoggedInMutex.Unlock()
+	if err != nil {
+		conn.Close()
+		log.Println(err)
+		return
+	}
 
-			holderConn := &utils.SSHConnection{
-				SSHConn:                sshConn,
-				Listeners:              syncmap.New[string, net.Listener](),
-				Closed:                 &sync.Once{},
-				Close:                  make(chan bool),
-				Exec:                   make(chan bool),
-				Messages:               make(chan string),
-				Session:                make(chan bool),
-				SetupLock:              &sync.Mutex{},
-				TCPAliasesAllowedUsers: []string{pubKeyFingerprint},
-			}
+	pubKeyFingerprint := ""
 
-			state.SSHConnections.Store(sshConn.RemoteAddr().String(), holderConn)
+	if sshConn.Permissions != nil {
+		if _, ok := sshConn.Permissions.Extensions["pubKey"]; ok {
+			pubKeyFingerprint = sshConn.Permissions.Extensions["pubKeyFingerprint"]
+		}
+	}
 
-			go func() {
-				err := sshConn.Wait()
-				if err != nil && viper.GetBool("debug") {
-					log.Println("Closing SSH connection:", err)
-				}
+	holderConn := &utils.SSHConnection{
+		SSHConn:                sshConn,
+		Listeners:              syncmap.New[string, net.Listener](),
+		Closed:                 &sync.Once{},
+		Close:                  make(chan bool),
+		Exec:                   make(chan bool),
+		Messages:               make(chan string),
+		Session:                make(chan bool),
+		SetupLock:              &sync.Mutex{},
+		TCPAliasesAllowedUsers: []string{pubKeyFingerprint},
+	}
 
-				select {
-				case <-holderConn.Close:
-					break
-				default:
+	state.SSHConnections.Store(sshConn.RemoteAddr().String(), holderConn)
+
+	go func() {
+		err := sshConn.Wait()
+		if err != nil && viper.GetBool("debug") {
+			log.Println("Closing SSH connection:", err)
+		}
+
+		select {
+		case <-holderConn.Close:
+			break
+		default:
+			holderConn.CleanUp(state)
+		}
+	}()
+
+	go handleRequests(reqs, holderConn, state)
+	go handleChannels(chans, holderConn, state)
+
+	go func() {
+		select {
+		case <-holderConn.Exec:
+		case <-time.After(1 * time.Second):
+			break
+		}
+
+		runTime := 0.0
+		ticker := time.NewTicker(1 * time.Second)
+
+		for {
+			select {
+			case <-ticker.C:
+				runTime++
+
+				if ((viper.GetBool("cleanup-unbound") && runTime > viper.GetDuration("cleanup-unbound-timeout").Seconds()) || holderConn.AutoClose) && holderConn.ListenerCount() == 0 {
+					holderConn.SendMessage("No forwarding requests sent. Closing connection.", true)
+					time.Sleep(1 * time.Millisecond)
 					holderConn.CleanUp(state)
 				}
-			}()
+			case <-holderConn.Close:
+				return
+			}
+		}
+	}()
 
-			go handleRequests(reqs, holderConn, state)
-			go handleChannels(chans, holderConn, state)
+	if viper.GetBool("ping-client") {
+		go func() {
+			tickDuration := viper.GetDuration("ping-client-interval")
+			ticker := time.NewTicker(tickDuration)
 
-			go func() {
-				select {
-				case <-holderConn.Exec:
-				case <-time.After(1 * time.Second):
-					break
+			for {
+				err := conn.SetDeadline(time.Now().Add(tickDuration).Add(viper.GetDuration("ping-client-timeout")))
+				if err != nil {
+					log.Println("Unable to set deadline")
 				}
 
-				runTime := 0.0
-				ticker := time.NewTicker(1 * time.Second)
-
-				for {
-					select {
-					case <-ticker.C:
-						runTime++
-
-						if ((viper.GetBool("cleanup-unbound") && runTime > viper.GetDuration("cleanup-unbound-timeout").Seconds()) || holderConn.AutoClose) && holderConn.ListenerCount() == 0 {
-							holderConn.SendMessage("No forwarding requests sent. Closing connection.", true)
-							time.Sleep(1 * time.Millisecond)
-							holderConn.CleanUp(state)
-						}
-					case <-holderConn.Close:
+				select {
+				case <-ticker.C:
+					_, _, err := sshConn.SendRequest("keepalive@sish", true, nil)
+					if err != nil {
+						log.Println("Error retrieving keepalive response:", err)
 						return
 					}
+				case <-holderConn.Close:
+					return
 				}
-			}()
-
-			if viper.GetBool("ping-client") {
-				go func() {
-					tickDuration := viper.GetDuration("ping-client-interval")
-					ticker := time.NewTicker(tickDuration)
-
-					for {
-						err := conn.SetDeadline(time.Now().Add(tickDuration).Add(viper.GetDuration("ping-client-timeout")))
-						if err != nil {
-							log.Println("Unable to set deadline")
-						}
-
-						select {
-						case <-ticker.C:
-							_, _, err := sshConn.SendRequest("keepalive@sish", true, nil)
-							if err != nil {
-								log.Println("Error retrieving keepalive response:", err)
-								return
-							}
-						case <-holderConn.Close:
-							return
-						}
-					}
-				}()
 			}
 		}()
 	}


### PR DESCRIPTION
Fixes #344

When an SSH connection drops right after requesting a remote forward (typical on a
flaky network), sish would build the forward anyway for the already-closed
connection. In the racy case the forwarding route was registered but never torn
down, so the subdomain/alias stayed **permanently reserved** until the process was
restarted. Repeated reconnects on a bad link leak routes and goroutines, which
matches the reports of the container dying a few minutes later.

The fix, in `handleRemoteForward`:

- Bail out (with a negative reply) if the connection already closed during setup,
  instead of standing up forwarding for a dead session.
- Start the `sshConn.Close` cleanup watcher only after the cleanup handler is
  assigned — previously it raced and could leak the route (also a data race under
  `-race`).
- Run cleanup when the forward reply fails, like the other error paths do.

`Start`'s per-connection logic is extracted into `handleConn` (no behavior change)
so the lifecycle can be tested.

Also adds a "forwarding stopped" log when a forward is torn down (the sidenote in
#344), mirroring the existing "forwarding started" log.

## Testing

New regression test drops the connection mid-setup and asserts the route table
drains to zero — fails before the fix, passes after. A second test confirms the
"forwarding stopped" log is emitted when a forward is torn down. Verified against a
real binary with a 60× reconnect-and-drop loop:

| Metric | Before | After |
| --- | --- | --- |
| Leaked HTTP routes | 23 | 0 |
| `forwarding started` for dead conns | 60 | 0 |
| `Error replying to port forwarding request: EOF` | present | none |
| Goroutines | stay elevated | settle to baseline |
